### PR TITLE
Pentest fixes

### DIFF
--- a/material/templates/admin/base.html
+++ b/material/templates/admin/base.html
@@ -58,7 +58,7 @@
         {% if messages %}
           <ul class="messagelist">
             {% for message in messages %}
-              <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message|capfirst }}</li>
+              <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message|capfirst|force_escape }}</li>
             {% endfor %}
           </ul>
         {% endif %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-material-admin
-version = 2023.7.21
+version = 2023.9.7
 license = MIT License
 license_files = LICENSE.TXT
 author = Anton Maistrenko


### PR DESCRIPTION
- Force-escape for the Django messages. Because of the `M.toast()` call in `admin.js`.