### PR TITLE
Unlock deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-material-admin
-version = 2023.10.4
+version = 2023.10.16
 license = MIT License
 license_files = LICENSE.TXT
 author = Anton Maistrenko

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,9 @@ packages =
   material.admin
   material.templatetags
 install_requires =
-  Django>=3.2,<4
-  Pillow<9.6
-  django-money>=2
+  Django
+  Pillow
+  django-money
   django-otp
   qrcode
 include_package_data = yes


### PR DESCRIPTION
Removed the version restrictions on the dependencies. These restrictions are preventing us from upgrading Django and Pillow (or even trying out to see what will happen if we upgrade them).